### PR TITLE
[ci skip] ***NO_CI*** Revert "Add 1.2.5 build for protobuf<4"

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "flyteidl" %}
-{% set version = "1.2.5" %}
+{% set version = "1.2.8" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/flyteidl-{{ version }}.tar.gz
-  sha256: dcd8b1f2cea254fa6f2b352361e7c8442a927b73ad1f8d92bff81576fdfcf916
+  sha256: ca55c04321c544bb35f83a563d853d06fd0e43808936f897d7fff5e9e90c3f91
 
 build:
   noarch: python
@@ -21,7 +21,7 @@ requirements:
   run:
     - python >=3.6
     - googleapis-common-protos
-    - protobuf >=3.5.0,<4.0.0
+    - protobuf >=4.21.1,<5.0.0
     - protoc-gen-swagger
 
 test:


### PR DESCRIPTION
Reverts conda-forge/flyteidl-feedstock#15 to restore 1.2.8 at head of 1.2 build branch.